### PR TITLE
solution

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,7 +50,32 @@ jobs:
           flake8 . --exit-zero --max-complexity=6
 
       - name: Upload python artifacts
+        if: github.ref_name == 'main'
         uses: actions/upload-artifact@v4
         with:
           name: python-artifacts
           path: .
+
+  docker-ci:
+    if: github.ref_name == 'main'
+    needs: 'python-ci'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download python artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: python-artifacts
+          path: .
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push Docker Image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./src
+          push: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/todoapp:${{ github.sha }}


### PR DESCRIPTION
Good day.
Please find below the reference to a workflow run with a successful Docker CI job.:
https://github.com/YegorVolkov/devops_todolist_cicd_task_3_docker_ci/actions/runs/10158222238

---

Please explain me why did the task have the requirements for jobs to be executed only from the main branch
This specific requirement makes me to merge solution in to main branch Before the mentor/superior review...

<img width="622" alt="image" src="https://github.com/user-attachments/assets/0faedc66-71b8-413e-9a83-d91523d2d91b">

---

As far as I understand in both cases either we are working on a forked repo or we are working directly on a project repo:
We need to reate a Pull Request from the `feature-branch` to the `main` branch of the original repository
And ONLY then **Code Review and Merge** in to `main` branch